### PR TITLE
Feat/more makefile conventions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LDFLAGS := -l lcms2 ${LDFLAGS}
 
 PREFIX ?= /usr/local
 BINDIR ?= ${PREFIX}/bin
-AUTO_START_PATH=/usr/share/gnome/autostart/
+AUTO_START_DIR=/etc/xdg/autostart
 
 all: icc-brightness-gen
 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
 # Copyright 2017 - 2019, Udi Fuchs
 # SPDX-License-Identifier: MIT
 
+CFLAGS := -Wall ${CFLAGS}
+LDFLAGS := -l lcms2 ${LDFLAGS}
+
 BIN_PATH=/usr/local/bin/
 AUTO_START_PATH=/usr/share/gnome/autostart/
 
 all: icc-brightness-gen
 
 icc-brightness-gen: icc-brightness-gen.c
-	$(CC) -W -Wall $(CFLAGS) $^ -l lcms2 $(LDFLAGS) -o $@
 
 clean:
 	rm -f icc-brightness-gen

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,5 @@ clean:
 	rm -f icc-brightness-gen
 
 install: all
-	mkdir -p $(DESTDIR)$(BINDIR)
-	install -m 755 icc-brightness-gen $(DESTDIR)$(BINDIR)
-	install -m 755 icc-brightness $(DESTDIR)$(BINDIR)
-	mkdir -p $(DESTDIR)$(AUTO_START_PATH)
-	install -m 644 icc-brightness.desktop $(DESTDIR)$(AUTO_START_PATH)
+	install -Dm755 -t $(DESTDIR)$(BINDIR) icc-brightness icc-brightness-gen
+	install -Dm644 -t $(DESTDIR)$(AUTO_START_DIR) icc-brightness.desktop

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@
 CFLAGS := -Wall ${CFLAGS}
 LDFLAGS := -l lcms2 ${LDFLAGS}
 
-BIN_PATH=/usr/local/bin/
+PREFIX ?= /usr/local
+BINDIR ?= ${PREFIX}/bin
 AUTO_START_PATH=/usr/share/gnome/autostart/
 
 all: icc-brightness-gen
@@ -15,8 +16,8 @@ clean:
 	rm -f icc-brightness-gen
 
 install: all
-	mkdir -p $(DESTDIR)$(BIN_PATH)
-	install -m 755 icc-brightness-gen $(DESTDIR)$(BIN_PATH)
-	install -m 755 icc-brightness $(DESTDIR)$(BIN_PATH)
+	mkdir -p $(DESTDIR)$(BINDIR)
+	install -m 755 icc-brightness-gen $(DESTDIR)$(BINDIR)
+	install -m 755 icc-brightness $(DESTDIR)$(BINDIR)
 	mkdir -p $(DESTDIR)$(AUTO_START_PATH)
 	install -m 644 icc-brightness.desktop $(DESTDIR)$(AUTO_START_PATH)


### PR DESCRIPTION
Well this is crazy timing. I'm getting ready to package this project for Arch Linux, and suddenly the most recent commit goes from 2 years old to 2 minutes old!

Rebased my changes on top of master following the merging of #7.

The most notable changes are:

- The addition of `${PREFIX}`, which allows the user to install to a different prefix other than `/usr/local`
- Changing `/usr/share/gnome/autostart` to `/etc/xdg/autostart`, which is supported by more WMs, and is also e.g. where GNOME puts all its global autostart .DESKTOP files now