### PR TITLE
icc-brightness: get_device_id returns first device that is listed as embedded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/venv/
+.idea/
+icc-brightness-gen

--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,17 @@ clean:
 install: all
 	install -Dm755 -t $(DESTDIR)$(BINDIR) icc-brightness icc-brightness-gen
 	install -Dm644 -t $(DESTDIR)$(AUTO_START_DIR) icc-brightness.desktop
+
+uninstall:
+	rm -f $(DESTDIR)$(BIN_PATH)icc-brightness-gen
+	rm -f $(DESTDIR)$(BIN_PATH)icc-brightness
+	rm -f $(DESTDIR)$(AUTO_START_PATH)icc-brightness.desktop
+
+local-install: BIN_PATH=~/.local/bin/
+local-install: AUTO_START_PATH=~/.config/autostart/
+local-install: install
+
+local-uninstall: BIN_PATH=~/.local/bin/
+local-uninstall: AUTO_START_PATH=~/.config/autostart/
+local-uninstall: uninstall
+

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Copyright 2017 - 2019, Udi Fuchs
 # SPDX-License-Identifier: MIT
 
-CFLAGS := -Wall ${CFLAGS}
+CFLAGS := -W -Wall -O2 ${CFLAGS}
 LDFLAGS := -l lcms2 ${LDFLAGS}
 
 PREFIX ?= /usr/local
@@ -11,6 +11,7 @@ AUTO_START_DIR=/etc/xdg/autostart
 all: icc-brightness-gen
 
 icc-brightness-gen: icc-brightness-gen.c
+	$(CC) $(CFLAGS) $^ $(LDFLAGS) -o $@
 
 clean:
 	rm -f icc-brightness-gen

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,20 @@
 # Copyright 2017 - 2019, Udi Fuchs
 # SPDX-License-Identifier: MIT
 
-BIN_PATH=/usr/local/bin/
-AUTO_START_PATH=/usr/share/gnome/autostart/
+CFLAGS := -Wall ${CFLAGS}
+LDFLAGS := -l lcms2 ${LDFLAGS}
+
+PREFIX ?= /usr/local
+BINDIR ?= ${PREFIX}/bin
+AUTO_START_DIR=/etc/xdg/autostart
 
 all: icc-brightness-gen
 
 icc-brightness-gen: icc-brightness-gen.c
-	$(CC) -W -Wall $(CFLAGS) $^ -l lcms2 $(LDFLAGS) -o $@
 
 clean:
 	rm -f icc-brightness-gen
 
 install: all
-	mkdir -p $(DESTDIR)$(BIN_PATH)
-	install -m 755 icc-brightness-gen $(DESTDIR)$(BIN_PATH)
-	install -m 755 icc-brightness $(DESTDIR)$(BIN_PATH)
-	mkdir -p $(DESTDIR)$(AUTO_START_PATH)
-	install -m 644 icc-brightness.desktop $(DESTDIR)$(AUTO_START_PATH)
+	install -Dm755 -t $(DESTDIR)$(BINDIR) icc-brightness icc-brightness-gen
+	install -Dm644 -t $(DESTDIR)$(AUTO_START_DIR) icc-brightness.desktop

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Lenovo ThinkPad X1 Yoga OLED display.
 
 The build requires the liblcms2 development package:
 ```
-$ sudo apt install liblcms2-dev 
+$ sudo apt install liblcms2-dev
 Reading package lists... Done
-Building dependency tree       
+Building dependency tree
 Reading state information... Done
 The following NEW packages will be installed:
   liblcms2-dev
@@ -36,7 +36,7 @@ $ make
 gcc -W -Wall icc-brightness-gen.c -l lcms2 -o icc-brightness-gen
 $ ./icc-brightness
 Control OLED display brightness by applying ICC color profiles.
-  
+
 icc-brightness brightness max-brightness - set brightness manually
 icc-brightness apply - apply brightness from system setting
 icc-brightness watch - continuously update to system setting
@@ -54,3 +54,29 @@ cp icc-brightness.desktop /usr/share/gnome/autostart/
 The daemon will start on your next login.
 You can change brightness using the brightness key or any other method
 that controls the display "backlight".
+
+To remove this global installation:
+```
+$ sudo make uninstall
+rm -f /usr/local/bin/icc-brightness-gen
+rm -f /usr/local/bin/icc-brightness
+rm -f /usr/share/gnome/autostart/icc-brightness.desktop
+```
+
+If you prefer to install this daemon as a local user:
+```
+$ make local-install
+mkdir -p ~/.local/bin/
+install -m 755 icc-brightness-gen ~/.local/bin/
+install -m 755 icc-brightness ~/.local/bin/
+mkdir -p ~/.config/autostart/
+install -m 644 icc-brightness.desktop ~/.config/autostart/
+```
+
+And you can remove this local installation with:
+```
+$ make local-uninstall
+rm -f ~/.local/bin/icc-brightness-gen
+rm -f ~/.local/bin/icc-brightness
+rm -f ~/.config/autostart/icc-brightness.desktop
+```

--- a/icc-brightness
+++ b/icc-brightness
@@ -66,9 +66,16 @@ def find_profile(filename):
 
 
 def get_device_id():
-    out = subprocess.check_output(['colormgr', 'get-devices-by-kind',
-                                   'display'])
-    return get_object_path(out)
+    device_id = None
+    out = subprocess.check_output(['colormgr', 'get-devices-by-kind', 'display'])
+    for line in out.decode('utf8').split('\n'):
+        if line.startswith('Object Path:'):
+            device_id = line.split(':')[1].lstrip()
+        elif line.startswith('Embedded:'):
+            embedded = line.split(':')[1].lstrip()
+            if embedded == "Yes":
+                break
+    return device_id
 
 
 last_icc_filename = None

--- a/icc-brightness
+++ b/icc-brightness
@@ -149,7 +149,7 @@ def main():
         fcntl.fcntl(fd, fcntl.F_NOTIFY, fcntl.DN_MODIFY| fcntl.DN_MULTISHOT)
 
         while True:
-            time.sleep(1000000)
+            signal.pause()
 
     elif len(sys.argv) == 3:
         brightness = int(sys.argv[1])


### PR DESCRIPTION
Summary of issue:

Without this change, icc-brightness takes the first monitor returned by `colormgr get-devices-by-kind display`. This works fine for single monitor setups however this isn't guaranteed to be the laptop's embedded monitor.

This change enhances the get_device_id() logic to not just look at the "Object Path:" output lines for monitor identifies but also the "Embedded:" lines. External monitors should show as "Embedded: No" whereas the laptop's monitor should show as "Embedded: Yes". With this extra check, icc-brightness can operate over the first embedded monitor regardless whether it is a primary or secondary monitor and the order of colormgr output.

Testing done:

I have a Dell XPS 15 7590 with 4K OLED display running on Ubuntu 20.04. icc-brightness only operates over my laptop's embedded monitor in a single monitor setup and when connected to two external monitors via my Dell WD19TB dock.

Known issues/limitations:

1. The brightness seems to reset to full when unplugging/plugging in the thunderbolt connector or after going from clamshell->open on the laptop. A single brightness change will make it jump down to the setting it should be at.
2. Is there a use case for non-embedded OLED displays? If so we may need to be smarter again.

(Somewhat) Related Issues:
https://github.com/udifuchs/icc-brightness/issues/12
https://github.com/udifuchs/icc-brightness/issues/21